### PR TITLE
Xpath query changes and customQueries

### DIFF
--- a/src/miningRulesCore/miningRules.js
+++ b/src/miningRulesCore/miningRules.js
@@ -56,10 +56,10 @@ in this process.
  */
 
 import {addChildren, addParentChildRelations, findParentChildRelations,
-        makePairsList, findCustomRelations, addCustomRelations} from "./mineRulesCore/sci_class";
+        makePairsList, findCustomRelations, addCustomRelations} from "./sci_class";
 
 import et from 'elementtree';
-import Utilities from "./utilities";
+import Utilities from "../core/utilities";
 
 /**
  *
@@ -222,7 +222,7 @@ export const mineRulesFromXmlFiles = (xmlFiles, support, metaData, ws, customQue
     for (const group of groupList.keys()){
       var grouping = groupList.get(group);
       addCustomRelations(allAttributes, customQueries, grouping, analysisFileName,
-                                   classLocations, parentInfo, fileAnalysisMap, dataMap);
+                        classLocations, parentInfo, fileAnalysisMap, dataMap, xmlFiles);
     }
 
     outputDataBases(dataMap, ws);
@@ -284,10 +284,10 @@ const outputDataBases = (dataMap, ws) => {
 const formatDatabases = (databases) => {
 
   // Write new contents
-  var finalFormat = new Array();
+  var finalFormat = [];
   for (var x = 0; x < databases.length; x++){
 
-    var table = new Array();
+    var table = [];
     // nameFile.txt
     var fileN = databases[x][0];
     table.push(fileN);
@@ -309,4 +309,19 @@ const formatDatabases = (databases) => {
     finalFormat.push(table);
   }
   return finalFormat;
+};
+
+// Leave this function in for debugging purposes
+export const dangerousParseMetaDataFile = (metaData) => {
+  let metaDataObject = {};
+    let lines = metaData.split("\n");
+
+    for (let i = 0; i < lines.length; i += 2) {
+        if (lines[i] === "") break;
+        let id = lines[i].split(" ")[0];
+        let attr = lines[i].substring(lines[i].indexOf(" ") + 1);
+        let query = lines[i + 1];
+        metaDataObject[id] = {attr: attr, query: query};
+    }
+    return metaDataObject;
 };

--- a/src/miningRulesCore/sci_class.js
+++ b/src/miningRulesCore/sci_class.js
@@ -134,10 +134,15 @@ export const addCustomRelations = (allAttributes, customQueries, classGroupings,
 
     if(f != undefined){
       f = f.split("\\")[(f.split("\\")).length - 1]
-      f = f.split(".")[0] + ".xml";
+      f = f.split(".")[0] + ".java";
 
-      var data = fs.readFileSync(f).toString();
-      classTree = et.parse(data);
+      let filtered = xmlFiles.filter(d => d["filePath"].endsWith(f));
+      if (filtered.length > 0)
+            classTree = et.parse(filtered[0]["xml"]);
+        if (filtered.length === 0) {
+            console.log("file not found: ", f);
+            continue;
+        }
 
     }
     else{
@@ -177,14 +182,13 @@ export const addCustomRelations = (allAttributes, customQueries, classGroupings,
         classesVisited.push(childName);
 
         // Get the list of attributes for this class
-        let fileN = analysisFileName + "_subClassOf" + parentClass + ".txt";
+        let fileN = analysisFileName + "_subClassOf_" + parentClass + ".txt";
         var entry = (dataMap.get(fileN));
 
         // Go through each of the customQueries. If the customQuery is present
         // in this class, then add its attribute id to the list of attributes
         // for the class
         for (var k = 0; k < customQueries.length; k++){
-          // THIS NEEDS TO GET EDITED
           let query = subCL[j].findall(customQueries[k].featureXpath);
 
           // If we found this customQuery, then we add it to the list of
@@ -207,7 +211,6 @@ export const addCustomRelations = (allAttributes, customQueries, classGroupings,
 
       }
     }
-  //console.log(newMap);
 }
 
 

--- a/src/miningRulesCore/sci_functions.js
+++ b/src/miningRulesCore/sci_functions.js
@@ -27,7 +27,7 @@ export const findClassAnnotations = (subCL, attributeList, id_start, queryMap) =
                     + (clsAnnot.find('name').text) +"\"]";
 
       if(annotArgs.length > 0){
-        clsAnnotName += " with \n";
+        clsAnnotName += " with ";
         for(let q = 0; q < annotArgs.length; q++){
 
           let node = annotArgs[q];
@@ -938,7 +938,7 @@ export const addClassAnnotations = (subCL, attributes, allAttributes) => {
                 + "\"";
 
             if (annotArgs.length > 0) {
-                name += " with \n";
+                name += " with ";
                 for (let q = 0; q < annotArgs.length; q++) {
 
                     let node = annotArgs[q];
@@ -1276,7 +1276,7 @@ export const addImplementations = (subCL, attributes, allAttributes) => {
   let classImplements = subCL.find('super/implements');
   if (classImplements != null){
       // New name
-      name = "class with implementation of \""
+      let name = "class with implementation of \""
              + (classImplements.find('name')).text + "\"";
 
      // Check whether attribute has been seen globally


### PR DESCRIPTION
miningRules now accepts customQueries array as a parameter. XPaths altered so that they can be easily combined later in other parts of ActiveDocumentation.

I would just double check that I correctly altered the XPaths as you directed and that I handle customQueries as you directed in your slack message to me.